### PR TITLE
Implement "Add New Task" screen

### DIFF
--- a/lib/features/home/presentation/pages/home_page.dart
+++ b/lib/features/home/presentation/pages/home_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:task_wise/core/constants/utils.dart';
 import 'package:task_wise/features/home/presentation/widgets/date_selector.dart';
 import 'package:task_wise/features/home/presentation/widgets/task_card.dart';
+import 'package:task_wise/features/task/presentation/pages/add_new_task.dart';
 
 class HomePage extends StatelessWidget {
   static route() => MaterialPageRoute(builder: (context) => HomePage());
@@ -15,7 +16,14 @@ class HomePage extends StatelessWidget {
       appBar: AppBar(
         centerTitle: true,
         title: Text("My Tasks"),
-        actions: [IconButton(onPressed: () {}, icon: Icon(CupertinoIcons.add))],
+        actions: [
+          IconButton(
+            onPressed: () {
+              Navigator.push(context, AddNewTaskPage.route());
+            },
+            icon: Icon(CupertinoIcons.add),
+          ),
+        ],
       ),
       body: Column(
         children: [

--- a/lib/features/task/presentation/pages/add_new_task.dart
+++ b/lib/features/task/presentation/pages/add_new_task.dart
@@ -1,0 +1,87 @@
+import 'package:flex_color_picker/flex_color_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class AddNewTaskPage extends StatefulWidget {
+  static route() => MaterialPageRoute(builder: (context) => AddNewTaskPage());
+
+  const AddNewTaskPage({super.key});
+
+  @override
+  State<AddNewTaskPage> createState() => _AddNewTaskPageState();
+}
+
+class _AddNewTaskPageState extends State<AddNewTaskPage> {
+  DateTime selectedDate = DateTime.now();
+  final TextEditingController _titleController = TextEditingController();
+  final TextEditingController _descriptionController = TextEditingController();
+  Color selectedColor = Color.fromRGBO(246, 222, 194, 1);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Add New Task"),
+        actions: [
+          GestureDetector(
+            onTap: () async {
+              final _selectedDate = await showDatePicker(
+                context: context,
+                firstDate: DateTime.now(),
+                lastDate: DateTime.now().add(Duration(days: 90)),
+              );
+              if (_selectedDate != null) {
+                setState(() {
+                  selectedDate = _selectedDate;
+                });
+              }
+            },
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Text(DateFormat("MM-d-y").format(selectedDate)),
+            ),
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _titleController,
+                decoration: InputDecoration(hintText: "Title"),
+              ),
+              SizedBox(height: 10),
+              TextFormField(
+                controller: _descriptionController,
+                decoration: InputDecoration(hintText: "Description"),
+                maxLines: 4,
+              ),
+              SizedBox(height: 10),
+              ColorPicker(
+                pickersEnabled: {ColorPickerType.wheel: true},
+                color: selectedColor,
+                heading: Text("Select Color"),
+                subheading: Text("Select a different shade"),
+                onColorChanged: (Color color) {
+                  setState(() {
+                    selectedColor = color;
+                  });
+                },
+              ),
+              SizedBox(height: 10),
+              ElevatedButton(
+                onPressed: () {},
+                child: Text(
+                  "SUBMIT",
+                  style: TextStyle(fontSize: 18, color: Colors.white),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -278,6 +278,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  flex_color_picker:
+    dependency: "direct main"
+    description:
+      name: flex_color_picker
+      sha256: "8f753a1a026a13ea5cc5eddbae3ceb886f2537569ab2e5208efb1e3bb5af72ff"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.7.1"
+  flex_seed_scheme:
+    dependency: transitive
+    description:
+      name: flex_seed_scheme
+      sha256: b06d8b367b84cbf7ca5c5603c858fa5edae88486c4e4da79ac1044d73b6c62ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.5.1"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   path_provider: ^2.1.0
   sqflite: ^2.4.2
   path: ^1.9.1
+  flex_color_picker: ^3.7.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This commit introduces the UI for adding a new task, allowing users to input task details and select a color.

Key changes include:

- **Dependencies:**
  - Added the `flex_color_picker` package to `pubspec.yaml` for color selection functionality.

- **"Add New Task" Screen:**
  - Created a new `AddNewTaskPage` stateful widget.
  - Implemented text fields for entering a task's title and description.
  - Integrated the `flex_color_picker` widget to allow users to select a custom color for the task.
  - Added a date picker that is triggered from the `AppBar`.
  - Included a "SUBMIT" button, though its functionality is not yet implemented.

- **Navigation:**
  - Connected the `HomePage` to the new screen by adding navigation logic to the `AppBar`'s add icon, which now directs users to the `AddNewTaskPage`.

Took 19 minutes